### PR TITLE
Bugfix for Live Scoreboard

### DIFF
--- a/domain/nba/nba_wins_pool_service.py
+++ b/domain/nba/nba_wins_pool_service.py
@@ -237,6 +237,7 @@ class NbaWinsPoolService:
     @staticmethod
     def build_scoreboard_df(game_data_df):
         df = game_data_df
+        df['date'] = pd.to_datetime(df["date"], errors='coerce', utc=True).dt.tz_convert('US/Eastern')
         df["score"] = df.apply(generate_score_str, axis=1)
         todays_games = df[(df["date"].max().month == df["date"].dt.month) & (df["date"].max().day == df["date"].dt.day)]
         return todays_games.sort_values(by="status")[["status", "score"]]


### PR DESCRIPTION
Dates pulled from the Live NBA.com scoreboard had a timezone component. This caused the date column in the dataframe to be of type `object`, since some rows had a timezone while others didn't. This mix caused the `.dt` accessor to fail.

Fixed by converting all dates to UTC, including ones without timezone information, and then converting all rows to Eastern time.