### PR TITLE
Hardcode correct score for UTA @ LAL on 1/17/22

### DIFF
--- a/domain/nba/nba_repository.py
+++ b/domain/nba/nba_repository.py
@@ -89,6 +89,8 @@ class NbaRepository:
         params = BallDontLieParams(start_date=start_date, end_date=live_date - timedelta(days=1))
         past_games = cls.client.games(params)
         for game in past_games:
+            if game["id"] == 474073:
+                game["home_team_score"] = 101
             yield NbaGame(
                 id=game["id"],
                 date=pd.Timestamp(game["date"]).astimezone('US/Eastern'),


### PR DESCRIPTION
BallDontLie API has the wrong final score for this game, causing it to be incorrectly recorded as a Lakers loss/Jazz win. Hardcoding the correct score to fix the issue.